### PR TITLE
SHAR-2 Implement a basic front end for uploading a video

### DIFF
--- a/SharpVids.sln
+++ b/SharpVids.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.9.34728.123
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpVids", "SharpVids\SharpVids\SharpVids.csproj", "{50F5F1B6-0A36-42A9-928A-06D309C19BFA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharpVids", "SharpVids\SharpVids\SharpVids.csproj", "{50F5F1B6-0A36-42A9-928A-06D309C19BFA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpVids.Client", "SharpVids\SharpVids.Client\SharpVids.Client.csproj", "{54C39202-0959-40FC-985E-79B57CD3844B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharpVids.Client", "SharpVids\SharpVids.Client\SharpVids.Client.csproj", "{54C39202-0959-40FC-985E-79B57CD3844B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/SharpVids/SharpVids/Components/Pages/Home.razor
+++ b/SharpVids/SharpVids/Components/Pages/Home.razor
@@ -3,3 +3,7 @@
 <PageTitle>SharpVids</PageTitle>
 
 <h1>SharpVids</h1>
+
+<nav>
+    <a href="/upload">Upload</a>
+</nav>

--- a/SharpVids/SharpVids/Components/Pages/Upload.razor
+++ b/SharpVids/SharpVids/Components/Pages/Upload.razor
@@ -1,0 +1,109 @@
+﻿@page "/upload"
+@rendermode InteractiveServer
+
+<article>
+    <h1>Upload Your Video!</h1>
+
+    <label for="video-upload">Video: </label>
+    <InputFile id="video-upload" OnChange="OnFileChanged" />
+
+    <button class="btn btn-outline-secondary" @onclick="UploadVideoAsync">Upload</button>
+</article>
+
+@if (errors.Count > 0)
+{
+    <section>
+        <h4>There were some errors trying to upload your video:</h4>
+        <ul>
+            @foreach (var error in errors)
+            {
+                <li><p class="alert-danger">@error</p></li>
+            }
+        </ul>
+    </section>
+}
+
+<h4>Upload Progress: @GetMbRemainingToUpload()MB Remaining (@GetCurrentVideoUploadPercentage()%)</h4>
+
+@code {
+    private void OnFileChanged(InputFileChangeEventArgs fileChange)
+    {
+        videoFileToUpload = fileChange.File;
+    }
+
+    private async Task UploadVideoAsync()
+    {
+        ResetUploadState();
+
+        try
+        {
+            await TryToReadVideoFromStreamAsync();
+        }
+        catch (Exception ex)
+        {
+            // FIXME: Catch specific exceptions and report human readable error messages
+            errors.Add(ex.Message);
+        }
+    }
+
+    private void ResetUploadState()
+    {
+        errors.Clear();
+        UploadedBytes = 0;
+    }
+
+    private async Task TryToReadVideoFromStreamAsync()
+    {
+        if (videoFileToUpload is null) return;
+
+        videoBytes = new byte[videoFileToUpload.Size];
+
+        // FIXME: Upload to a NoSQL database to be encoded
+        // FIXME: Allow a user to cancel an upload using cancellation tokens
+        using var videoStream = videoFileToUpload.OpenReadStream(50 * MB);
+        while (UploadedBytes != videoFileToUpload.Size)
+        {
+            await videoStream.ReadAsync(videoBytes.Slice((int)videoStream.Position));
+            UploadedBytes = videoStream.Position;
+        }
+    }
+
+    private string GetMbRemainingToUpload()
+    {
+        var diffInBytes = VideoFileSize - UploadedBytes;
+        var mbRemaining = diffInBytes / (float)MB;
+        return mbRemaining.ToString("N2");
+    }
+
+    private string GetCurrentVideoUploadPercentage()
+    {
+        if (VideoFileSize == 0) return "0.00";
+
+        var currentCompleted = UploadedBytes / (float)VideoFileSize;
+        var uploadPercentage = currentCompleted * 100;
+        return uploadPercentage.ToString("N2");
+    }
+
+    const int MB = 1024 * 1024;
+
+    // FIXME: Implement a file size limitation and display it to the user (IOptionsMonitor<VideoUploadingOptions>)
+    // FIXME: Implement other client-side validation for the file to upload
+    private IBrowserFile? videoFileToUpload;
+    private List<string> errors = [];
+    private Memory<byte> videoBytes = new();
+
+    private long _uploadedBytes = 0;
+    private long UploadedBytes
+    {
+        get => _uploadedBytes;
+        set
+        {
+            _uploadedBytes = value;
+            StateHasChanged();
+        }
+    }
+    private long VideoFileSize
+    {
+        get => videoBytes.Length;
+    }
+}


### PR DESCRIPTION
We now have a basic front end for a user to select and upload a video.

We also show the user the remaining mb and percentage of the video to be uploaded during the upload.

Currently, we only store the video in memory, but in the future we will store the raw video into a NoSQL database to be encoded.